### PR TITLE
v0.004 - remove Moose dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author           = Keedi Kim - 김도형 <keedi@cpan.org>
 license          = Perl_5
 copyright_holder = Keedi Kim
 copyright_year   = 2012
-version          = 0.003
+version          = 0.004
 
 ;[@Basic]
 [@Filter]
@@ -23,9 +23,6 @@ repository.type = git
 [PkgVersion]
 [ReadmeMarkdownFromPod]
 [InstallGuide]
-
-[Prereqs / RuntimeRequires]
-Moose = 0
 
 [PodCoverageTests]
 [PodSyntaxTests]


### PR DESCRIPTION
This pull request removes moose from the dependency chain for Markdown::Pod.

As far as I can tell, Moose was largely being used for the
validated_list() functionality. I hand-rolled one on the
train ride home which just uses base Perl but honors the
same interface (more or less; it croaks on failure, which
you may not like).

This class mostly provides a class-based interface, not an
object-based one; it doesn't have any Moose attributes. I
removed MooseX::StrictConstructor.
