### PR TITLE
Adding handler support for HTML entities.

### DIFF
--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -298,6 +298,13 @@ sub line_break {
     $self->_stream( "\n\n" );
 }
 
+sub html_entity {
+    my $self = shift;
+    my ($entity) = validated_list( \@_, entity => { isa => Str } );
+
+    $self->_stream( "E<$entity>" );
+}
+
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/t/html-entities.t
+++ b/t/html-entities.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Encode qw( decode_utf8 );
+use File::Slurp;
+use Markdown::Pod;
+
+my $file = 't/mkd/html-entities.mkd';
+
+my $m2p = Markdown::Pod->new;
+my $src = read_file(\*DATA);
+my $dst = $m2p->markdown_to_pod(
+    encoding => 'utf8',
+    markdown => decode_utf8(read_file($file)),
+);
+
+$src =~ s/\s+\Z//gsm;
+$dst =~ s/\s+\Z//gsm;
+
+is $dst, $src, "converting $file";
+
+__DATA__
+=encoding utf8
+
+I ate fish E<amp> chips for lunch.

--- a/t/mkd/html-entities.mkd
+++ b/t/mkd/html-entities.mkd
@@ -1,0 +1,1 @@
+I ate fish &amp; chips for lunch.


### PR DESCRIPTION
Currently, markdown2pod crashes if it encounters an HTML entity such as `&amp;` or `&lt;` in the source text. This is because its handler does not define the `html_entity` method that Markdent::Role::EventsAsMethods expects.

This patch provides this method, transforming the given HTML entity into a POD `E<...>` entity. It also provides a trivial test for it.
