### PR TITLE
Formatting fixes to Markdown-Pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ convert markdown text to POD text
 
 Keedi Kim - 김도형 <keedi@cpan.org>
 
+# CONTRIBUTORS
+
+- Abigail (ABIGAIL)
+- Jason McIntosh (JMAC)
+
 # COPYRIGHT AND LICENSE
 
 This software is copyright (c) 2013 by Keedi Kim.

--- a/README.md
+++ b/README.md
@@ -53,11 +53,6 @@ convert markdown text to POD text
 
 Keedi Kim - 김도형 <keedi@cpan.org>
 
-# CONTRIBUTORS
-
-- Abigail (ABIGAIL)
-- Jason McIntosh (JMAC)
-
 # COPYRIGHT AND LICENSE
 
 This software is copyright (c) 2013 by Keedi Kim.

--- a/dist.ini
+++ b/dist.ini
@@ -48,7 +48,7 @@ remove = Markdent::Types
 [PodSyntaxTests]
 
 [PodWeaver]
-config_plugin = @KEEDI
+#config_plugin = @KEEDI
 
 [%PodWeaver]
 Contributors.contributors[0] = Abigail (ABIGAIL)

--- a/lib/Markdown/Pod.pm
+++ b/lib/Markdown/Pod.pm
@@ -18,7 +18,7 @@ sub markdown_to_pod {
     my $self = shift;
     my ( $dialect, $markdown, $encoding ) = validated_list(
         \@_,
-        dialect  => { isa => Str, default => 'Standard' },
+        dialect  => { isa => Str, default => 'Standard', optional => 1 },
         markdown => { isa => Str },
         encoding => { isa => Str, default => q{}, optional => 1 },
     );
@@ -57,17 +57,19 @@ sub markdown_to_pod {
     # FIXME
     # dirty code to support blockquote
     #
-    $capture =~ s{
-        ^ =begin \s+ blockquote
-        \s+
-        (.*?)
-        \s+
-        ^ =end \s+ blockquote
-    }{
-        my $quoted = $1;
-        $quoted =~ s/^/    /gsm;
-        $quoted;
-    }xgsme;
+    # UPDATE A.Speer - not needed, blockquote converted to use =over 2, =back
+    #
+    #$capture =~ s{
+    #    ^ =begin \s+ blockquote
+    #    \s+
+    #    (.*?)
+    #    \s+
+    #    ^ =end \s+ blockquote
+    #}{
+    #    my $quoted = $1;
+    #    $quoted =~ s/^/    /gsm;
+    #    $quoted;
+    #}xgsme;
 
     return $capture;
 }

--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -239,6 +239,13 @@ sub end_code {
     $code_buf=undef;
 }
 
+sub code_block {
+    my $self=shift();
+    my ($code) = validated_list( \@_, code => { isa => Str }, language => { isa => Str, optional => 1 } );
+    $code=~s/^(.*)$/ $1/mg;
+    $self->_stream("\n$code\n");
+}
+
 sub image {
     my $self = shift;
     my %p    = validated_hash(

--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -28,7 +28,15 @@ has _output => (
     init_arg => 'output',
 );
 
+
+#  Default width for horizontal rule
+#
+our $HORIZONTAL_RULE_WIDTH=80;
+
 my $link_buf;
+my $code_buf;
+my $tble_buf;
+my @tble=([]);
 my @blockquotes;
 my @list_type;
 
@@ -51,6 +59,12 @@ sub text {
 
     if ( $link_buf ) {
         $link_buf->{text} = $text;
+    }
+    elsif ( $code_buf ) {
+        $code_buf->{text} = $text;
+    }
+    elsif ( $tble_buf ) {
+        $tble_buf->{text} = $text;
     }
     else {
         $self->_stream( $text );
@@ -152,13 +166,13 @@ sub preformatted {
 sub start_blockquote {
     my $self  = shift;
 
-    $self->_stream("=begin blockquote\n\n");
+    $self->_stream("=over 2\n\n");
 }
 
 sub end_blockquote {
     my $self  = shift;
 
-    $self->_stream("=end blockquote\n\n");
+    $self->_stream("=back\n\n");
 }
 
 sub start_unordered_list {
@@ -203,14 +217,26 @@ sub end_list_item {
 
 sub start_code {
     my $self = shift;
-
-    $self->_stream('C<');
+    #  Start buffering this snippet
+    $code_buf={};
 }
+
 
 sub end_code {
     my $self = shift;
-
-    $self->_stream('>');
+    my $text=$code_buf->{'text'};
+    if ($text=~/\n/m) {
+        #  Multi-line. Probably code block
+        #
+        $text=~s/^(.*)$/ $1/mg;
+        $self->_stream($text);
+    }
+    else {
+        #  Single line
+        #
+        $self->_stream("C<<< $text >>>");
+    }
+    $code_buf=undef;
 }
 
 sub image {
@@ -305,6 +331,80 @@ sub html_entity {
     $self->_stream( "E<$entity>" );
 }
 
+
+# Added A.Speer
+sub horizontal_rule {
+    my $self=shift();
+    $self->_stream( ('=' x $HORIZONTAL_RULE_WIDTH)."\n" );
+}
+
+sub auto_link {
+    my $self=shift();
+    my ($uri) = validated_list( \@_, uri => { isa => Str } );
+    $self->_stream( "L<$uri>" );
+}    
+
+
+sub html_comment_block {
+    my $self=shift();
+    # Stub
+}    
+
+
+sub start_table {
+    my $self=shift();
+    # Stub 
+}
+
+sub start_table_body {
+    my $self=shift();
+    # Stub 
+}
+
+sub start_table_row {
+    my $self=shift();
+    # Stub 
+}
+
+sub start_table_cell {
+    my $self=shift();
+    $tble_buf={};
+}
+
+sub end_table {
+    my $self=shift();
+    eval {
+        require Text::Table::Tiny;
+        1;
+    } || die ('unable to load Text::Table::Tiny - please make sure it is installed !');
+    my $table=Text::Table::Tiny::table(rows=>\@tble, separate_rows => 0, header_row => 0);
+    #  Indent so table appears as POD code. Open to other suggestions
+    $table=~s/^(.*)/  $1/mg;
+    $table.="\n";
+    #  Safety in case parser skips end-cell - which it seems to do sometimes
+    $tble_buf=undef;
+    $self->_stream($table);
+}
+
+sub end_table_body {
+    my $self=shift();
+    #  Safety
+    $tble_buf=undef;
+}
+
+sub end_table_row {
+    my $self=shift();
+    push @tble,[];
+    #  Safety
+    $tble_buf=undef;
+}
+
+sub end_table_cell {
+    my $self=shift();
+    push @{$tble[$#tble]}, $tble_buf->{'text'};
+    #  Stop buffering table text
+    $tble_buf=undef;
+}
 
 __PACKAGE__->meta->make_immutable;
 no Moose;

--- a/lib/Markdown/Pod/script.pm
+++ b/lib/Markdown/Pod/script.pm
@@ -14,6 +14,7 @@ sub new {
 
     bless {
         encoding => 'utf8',
+        dialect  => 'Standard',
         verbose  => undef,
         argv     => [],
         @_,
@@ -45,6 +46,7 @@ sub doit {
 
         my $pod = $m2p->markdown_to_pod(
             encoding => $self->{encoding},
+            dialect => $self->{dialect},
             markdown => $markdown,
         );
         print $self->{encoding} ? decode( $self->{encoding}, $pod ) : $pod;
@@ -58,6 +60,7 @@ sub doit {
 
         my $pod = $m2p->markdown_to_pod(
             encoding => $self->{encoding},
+            dialect => $self->{dialect},
             markdown => $markdown,
         );
         print $self->{encoding} ? decode( $self->{encoding}, $pod ) : $pod;
@@ -68,7 +71,6 @@ sub doit {
 
 sub env {
     my ($self, $key) = @_;
-
     return $ENV{"PERL_MARKDOWN2POD_" . $key} || q{};
 }
 
@@ -82,6 +84,7 @@ sub parse_options {
     Getopt::Long::Configure("bundling");
     Getopt::Long::GetOptions(
         'e|encoding=s' => sub { $self->{encoding} = $_[1] },
+        'd|dialect=s'  => sub { $self->{dialect} = $_[1] },
         'v|verbose'    => sub { $self->{verbose} = 1 },
         'h|help'       => sub { $self->{action}  = 'show_help' },
         'V|version'    => sub { $self->{action}  = 'show_version' },
@@ -110,6 +113,7 @@ Usage: markdown2pod [OPTIONS] <file1> [ <file2> ... ]
 
 OPTIONS:
     -e,--encoding       set markdown encoding
+    -d,--dialect        set markdown dialect (Standard, Github, Theory)
     -v,--verbose        print more information
     -h,--help           print this message
     -V,--version        display software version


### PR DESCRIPTION
Hello Keedi, I have forked the Markdown-Pod module and made some changes including:

+ Adding --dialect option to script command line
+ Adding missing methods (e.g. auto_link, horizontal rule) to Handler.pm
+ Adding simple table formatting to Handler.pm
+ Changing block-quote formatting so it produces output compatible with Pod::Simple::HTML

Sample output from patched and pre-patched module can be found at:

[https://github.com/aspeer/markdown-pod-testing]

I have tried to use the same coding style but if you accept the changes feel free to change as desired and remove any notes/comments I have added.

Regards, Andrew

