### PR TITLE
Markdent v0.27 uses Specio for types

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,7 +18,7 @@ stopwords = doit
 stopwords = env
 
 [Prereqs / RuntimeRequires]
-Markdent = 0.25
+Markdent = 0.27
 [Prereqs / TestRequires]
 Test::More = 0
 [RemovePrereqs]

--- a/lib/Markdown/Pod.pm
+++ b/lib/Markdown/Pod.pm
@@ -20,9 +20,9 @@ sub markdown_to_pod {
     my $self = shift;
     my ( $dialect, $markdown, $encoding ) = validated_list(
         \@_,
-        dialect  => { isa => Str, default => 'Standard', optional => 1 },
-        markdown => { isa => Str },
-        encoding => { isa => Str, default => q{},        optional => 1 },
+        dialect  => { type => 'Str', default => 'Standard', optional => 1 },
+        markdown => { type => 'Str' },
+        encoding => { type => 'Str', default => q{},        optional => 1 },
     );
 
     my $capture = q{};

--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -20,13 +20,13 @@ with 'Markdent::Role::EventsAsMethods';
 
 has encoding => (
     is      => 'ro',
-    isa     => Str,
+    isa     => t('Str'),
     default => q{},
 );
 
 has _output => (
     is       => 'ro',
-    isa      => OutputStream,
+    isa      => t('OutputStream'),
     required => 1,
     init_arg => 'output',
 );
@@ -67,7 +67,7 @@ sub end_document { }
 
 sub text {
     my $self = shift;
-    my ($text) = validated_list( \@_, text => { isa => Str } );
+    my ($text) = validated_list( \@_, text => { type => 'Str' } );
 
     if (@style_stack) {
         # This allows the end_link() handler to know that *some* text was inside
@@ -97,14 +97,14 @@ sub text {
 
 sub start_header {
     my $self = shift;
-    my ($level) = validated_list( \@_, level => { isa => HeaderLevel }, );
+    my ($level) = validated_list( \@_, level => { type => 'HeaderLevel' }, );
 
     $self->_stream("\n=head$level ");
 }
 
 sub end_header {
     my $self = shift;
-    my ($level) = validated_list( \@_, level => { isa => HeaderLevel }, );
+    my ($level) = validated_list( \@_, level => { type => 'HeaderLevel' }, );
 
     $self->_stream("\n");
 }
@@ -123,10 +123,10 @@ sub start_link {
     my $self = shift;
     my %p    = validated_hash(
         \@_,
-        uri            => { isa => Str },
-        title          => { isa => Str, optional => 1 },
-        id             => { isa => Str, optional => 1 },
-        is_implicit_id => { isa => Bool, optional => 1 },
+        uri            => { type => 'Str' },
+        title          => { type => 'Str', optional => 1 },
+        id             => { type => 'Str', optional => 1 },
+        is_implicit_id => { type => 'Bool', optional => 1 },
     );
 
     delete @p{ grep { !defined $p{$_} } keys %p };
@@ -180,7 +180,7 @@ sub end_emphasis {
 
 sub preformatted {
     my $self = shift;
-    my ($text) = validated_list( \@_, text => { isa => Str }, );
+    my ($text) = validated_list( \@_, text => { type => 'Str' }, );
 
     chomp $text;
     $text =~ s/^/    /gsm;
@@ -225,7 +225,7 @@ sub end_ordered_list {
 
 sub start_list_item {
     my $self = shift;
-    my %p = validated_hash( \@_, bullet => { isa => Str }, );
+    my %p = validated_hash( \@_, bullet => { type => 'Str' }, );
 
     $self->_stream("=item $p{bullet}\n\n");
 }
@@ -277,8 +277,8 @@ sub code_block {
     my $self = shift;
     my ($code) = validated_list(
         \@_,
-        code     => { isa => Str },
-        language => { isa => Str, optional => 1 }
+        code     => { type => 'Str' },
+        language => { type => 'Str', optional => 1 }
     );
     $code =~ s/^(.*)$/ $1/mg;
     $self->_stream("\n$code\n");
@@ -288,11 +288,11 @@ sub image {
     my $self = shift;
     my %p    = validated_hash(
         \@_,
-        alt_text       => { isa => Str },
-        uri            => { isa => Str, optional => 1 },
-        title          => { isa => Str, optional => 1 },
-        id             => { isa => Str, optional => 1 },
-        is_implicit_id => { isa => Bool, optional => 1 },
+        alt_text       => { type => 'Str' },
+        uri            => { type => 'Str', optional => 1 },
+        title          => { type => 'Str', optional => 1 },
+        id             => { type => 'Str', optional => 1 },
+        is_implicit_id => { type => 'Bool', optional => 1 },
     );
 
     delete @p{ grep { !defined $p{$_} } keys %p };
@@ -315,22 +315,22 @@ sub start_html_tag {
     my $self = shift;
     my ( $tag, $attributes ) = validated_list(
         \@_,
-        tag        => { isa => Str },
-        attributes => { isa => HashRef },
+        tag        => { type => 'Str' },
+        attributes => { type => 'HashRef' },
     );
 }
 
 sub end_html_tag {
     my $self = shift;
-    my ( $tag, $attributes ) = validated_list( \@_, tag => { isa => Str }, );
+    my ( $tag, $attributes ) = validated_list( \@_, tag => { type => 'Str' }, );
 }
 
 sub html_tag {
     my $self = shift;
     my ( $tag, $attributes ) = validated_list(
         \@_,
-        tag        => { isa => Str },
-        attributes => { isa => HashRef },
+        tag        => { type => 'Str' },
+        attributes => { type => 'HashRef' },
     );
 
     my $attributes_str = q{};
@@ -346,7 +346,7 @@ sub html_tag {
 
 sub html_block {
     my $self = shift;
-    my ($html) = validated_list( \@_, html => { isa => Str }, );
+    my ($html) = validated_list( \@_, html => { type => 'Str' }, );
 
     chomp $html;
     $self->_output()->print(
@@ -369,7 +369,7 @@ sub line_break {
 
 sub html_entity {
     my $self = shift;
-    my ($entity) = validated_list( \@_, entity => { isa => Str } );
+    my ($entity) = validated_list( \@_, entity => { type => 'Str' } );
 
     $self->_stream("E<$entity>");
 }
@@ -382,7 +382,7 @@ sub horizontal_rule {
 
 sub auto_link {
     my $self = shift;
-    my ($uri) = validated_list( \@_, uri => { isa => Str } );
+    my ($uri) = validated_list( \@_, uri => { type => 'Str' } );
     $self->_stream("L<$uri>");
 }
 


### PR DESCRIPTION
This updates the distribution to be in line with Markdent::Types from
Markdent v0.27 which has switched to using Specio instead of
MooseX::Types.

The changes required to do this are:

  - Surround the type with quotes to avoid bareword error
    (e.g., Str -> 'Str').
  - Changing the `isa` option value for `has` attributes to use
    `t('Type')`.
  - Changing the `isa` option key of MooseX::Params::Validate's
    `validated_*` to `type`.

A future change could be to replace MooseX::Params::Validate with
Params::ValidationCompiler like Markdent v0.27 does, but that can be
done at another time.

Fixes <https://github.com/keedi/Markdown-Pod/issues/8>.
