### PR TITLE
Add extra newline when starting a nested list

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,7 +18,7 @@ stopwords = doit
 stopwords = env
 
 [Prereqs / RuntimeRequires]
-Markdent = 0.25
+Markdent = 0.27
 [Prereqs / TestRequires]
 Test::More = 0
 [RemovePrereqs]

--- a/lib/Markdown/Pod.pm
+++ b/lib/Markdown/Pod.pm
@@ -20,9 +20,9 @@ sub markdown_to_pod {
     my $self = shift;
     my ( $dialect, $markdown, $encoding ) = validated_list(
         \@_,
-        dialect  => { isa => Str, default => 'Standard', optional => 1 },
-        markdown => { isa => Str },
-        encoding => { isa => Str, default => q{},        optional => 1 },
+        dialect  => { type => 'Str', default => 'Standard', optional => 1 },
+        markdown => { type => 'Str' },
+        encoding => { type => 'Str', default => q{},        optional => 1 },
     );
 
     my $capture = q{};

--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -20,13 +20,13 @@ with 'Markdent::Role::EventsAsMethods';
 
 has encoding => (
     is      => 'ro',
-    isa     => Str,
+    isa     => t('Str'),
     default => q{},
 );
 
 has _output => (
     is       => 'ro',
-    isa      => OutputStream,
+    isa      => t('OutputStream'),
     required => 1,
     init_arg => 'output',
 );
@@ -67,7 +67,7 @@ sub end_document { }
 
 sub text {
     my $self = shift;
-    my ($text) = validated_list( \@_, text => { isa => Str } );
+    my ($text) = validated_list( \@_, text => { type => 'Str' } );
 
     if (@style_stack) {
         # This allows the end_link() handler to know that *some* text was inside
@@ -97,14 +97,14 @@ sub text {
 
 sub start_header {
     my $self = shift;
-    my ($level) = validated_list( \@_, level => { isa => HeaderLevel }, );
+    my ($level) = validated_list( \@_, level => { type => 'HeaderLevel' }, );
 
     $self->_stream("\n=head$level ");
 }
 
 sub end_header {
     my $self = shift;
-    my ($level) = validated_list( \@_, level => { isa => HeaderLevel }, );
+    my ($level) = validated_list( \@_, level => { type => 'HeaderLevel' }, );
 
     $self->_stream("\n");
 }
@@ -123,10 +123,10 @@ sub start_link {
     my $self = shift;
     my %p    = validated_hash(
         \@_,
-        uri            => { isa => Str },
-        title          => { isa => Str, optional => 1 },
-        id             => { isa => Str, optional => 1 },
-        is_implicit_id => { isa => Bool, optional => 1 },
+        uri            => { type => 'Str' },
+        title          => { type => 'Str', optional => 1 },
+        id             => { type => 'Str', optional => 1 },
+        is_implicit_id => { type => 'Bool', optional => 1 },
     );
 
     delete @p{ grep { !defined $p{$_} } keys %p };
@@ -180,7 +180,7 @@ sub end_emphasis {
 
 sub preformatted {
     my $self = shift;
-    my ($text) = validated_list( \@_, text => { isa => Str }, );
+    my ($text) = validated_list( \@_, text => { type => 'Str' }, );
 
     chomp $text;
     $text =~ s/^/    /gsm;
@@ -225,7 +225,7 @@ sub end_ordered_list {
 
 sub start_list_item {
     my $self = shift;
-    my %p = validated_hash( \@_, bullet => { isa => Str }, );
+    my %p = validated_hash( \@_, bullet => { type => 'Str' }, );
 
     $self->_stream("=item $p{bullet}\n\n");
 }
@@ -277,8 +277,8 @@ sub code_block {
     my $self = shift;
     my ($code) = validated_list(
         \@_,
-        code     => { isa => Str },
-        language => { isa => Str, optional => 1 }
+        code     => { type => 'Str' },
+        language => { type => 'Str', optional => 1 }
     );
     $code =~ s/^(.*)$/ $1/mg;
     $self->_stream("\n$code\n");
@@ -288,11 +288,11 @@ sub image {
     my $self = shift;
     my %p    = validated_hash(
         \@_,
-        alt_text       => { isa => Str },
-        uri            => { isa => Str, optional => 1 },
-        title          => { isa => Str, optional => 1 },
-        id             => { isa => Str, optional => 1 },
-        is_implicit_id => { isa => Bool, optional => 1 },
+        alt_text       => { type => 'Str' },
+        uri            => { type => 'Str', optional => 1 },
+        title          => { type => 'Str', optional => 1 },
+        id             => { type => 'Str', optional => 1 },
+        is_implicit_id => { type => 'Bool', optional => 1 },
     );
 
     delete @p{ grep { !defined $p{$_} } keys %p };
@@ -315,22 +315,22 @@ sub start_html_tag {
     my $self = shift;
     my ( $tag, $attributes ) = validated_list(
         \@_,
-        tag        => { isa => Str },
-        attributes => { isa => HashRef },
+        tag        => { type => 'Str' },
+        attributes => { type => 'HashRef' },
     );
 }
 
 sub end_html_tag {
     my $self = shift;
-    my ( $tag, $attributes ) = validated_list( \@_, tag => { isa => Str }, );
+    my ( $tag, $attributes ) = validated_list( \@_, tag => { type => 'Str' }, );
 }
 
 sub html_tag {
     my $self = shift;
     my ( $tag, $attributes ) = validated_list(
         \@_,
-        tag        => { isa => Str },
-        attributes => { isa => HashRef },
+        tag        => { type => 'Str' },
+        attributes => { type => 'HashRef' },
     );
 
     my $attributes_str = q{};
@@ -346,7 +346,7 @@ sub html_tag {
 
 sub html_block {
     my $self = shift;
-    my ($html) = validated_list( \@_, html => { isa => Str }, );
+    my ($html) = validated_list( \@_, html => { type => 'Str' }, );
 
     chomp $html;
     $self->_output()->print(
@@ -369,7 +369,7 @@ sub line_break {
 
 sub html_entity {
     my $self = shift;
-    my ($entity) = validated_list( \@_, entity => { isa => Str } );
+    my ($entity) = validated_list( \@_, entity => { type => 'Str' } );
 
     $self->_stream("E<$entity>");
 }
@@ -382,7 +382,7 @@ sub horizontal_rule {
 
 sub auto_link {
     my $self = shift;
-    my ($uri) = validated_list( \@_, uri => { isa => Str } );
+    my ($uri) = validated_list( \@_, uri => { type => 'Str' } );
     $self->_stream("L<$uri>");
 }
 

--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -52,6 +52,8 @@ use constant {
 
 my @style_stack;
 
+my $list_depth = 0;
+
 sub _stream {
     my ( $self, @params ) = @_;
     print { $self->_output } @params;
@@ -202,24 +204,30 @@ sub end_blockquote {
 sub start_unordered_list {
     my $self = shift;
 
+    $self->_stream("\n") if $list_depth;
+    $list_depth++;
     $self->_stream("=over\n\n");
 }
 
 sub end_unordered_list {
     my $self = shift;
 
+    $list_depth--;
     $self->_stream("=back\n\n");
 }
 
 sub start_ordered_list {
     my $self = shift;
 
+    $self->_stream("\n") if $list_depth;
+    $list_depth++;
     $self->_stream("=over\n\n");
 }
 
 sub end_ordered_list {
     my $self = shift;
 
+    $list_depth--;
     $self->_stream("=back\n\n");
 }
 

--- a/t/github-7-nested-lists.mkd.t
+++ b/t/github-7-nested-lists.mkd.t
@@ -1,0 +1,75 @@
+use lib 't/lib';
+use strict;
+use warnings;
+use Test::More tests => 1;
+use Markdown::Pod::Test qw( get_pod markdown_to_pod );
+
+my $file = 't/mkd/github-7-nested-lists.mkd';
+is markdown_to_pod($file), get_pod( \*DATA ), "converting $file";
+
+__DATA__
+=encoding utf8
+
+=over
+
+=item *
+
+Fruits
+
+=over
+
+=item *
+
+Apples
+
+
+=item *
+
+Oranges
+
+
+=back
+
+
+
+=item *
+
+Vegetables
+
+=over
+
+=item *
+
+Carrots
+
+
+=item *
+
+Peppers
+
+=over
+
+=item *
+
+Chili Peppers
+
+
+=item *
+
+Bell Peppers
+
+
+=back
+
+
+
+=item *
+
+Lettuce
+
+
+=back
+
+
+
+=back

--- a/t/mkd/github-7-nested-lists.mkd
+++ b/t/mkd/github-7-nested-lists.mkd
@@ -1,0 +1,9 @@
+* Fruits
+    * Apples
+    * Oranges
+* Vegetables
+    * Carrots
+    * Peppers
+        * Chili Peppers
+        * Bell Peppers
+    * Lettuce


### PR DESCRIPTION
Since a nested list's `=over` directive can not appear directly after
the text of the bullet of the surrounding list, any list that is nested
within a top-level list has a newline inserted before it starts.

Fixes <https://github.com/keedi/Markdown-Pod/issues/7>.

