### PR TITLE
fix boolean HTML attribute handling

### DIFF
--- a/lib/Markdown/Pod/Handler.pm
+++ b/lib/Markdown/Pod/Handler.pm
@@ -341,7 +341,11 @@ sub html_tag {
 
     my $attributes_str = q{};
     $attributes_str = join q{ },
-        map { qq|$_="$attributes->{$_}"| } sort keys %$attributes;
+        map {
+            defined $attributes->{$_}
+                ? qq|$_="$attributes->{$_}"|
+                : qq|$_|
+            } sort keys %$attributes;
     if ( $tag =~ /^br$/i ) {
         $self->_stream(qq|<$tag $attributes_str />\n|);
     }

--- a/t/2011-12-18.mkd.t
+++ b/t/2011-12-18.mkd.t
@@ -387,7 +387,7 @@ C<Wire.receive()>를 C<Wire.read()>로 변경합니다.
 
 L<동영상1. Nunchuck 마우스|http://www.youtube.com/watch?v=1_gaxw9GKRg>
 <br  />
-
+<iframe allowfullscreen frameborder="0" height="315" src="http://www.youtube.com/embed/1_gaxw9GKRg" width="560" />
 
 
 =back


### PR DESCRIPTION
When we try to convert some HTML attribute that does not have value
such as boolean attribute(e.g. allowfullscreen), these attributes are
considered valued and also will cause a test failure with
t/2011-12-18.mkd.t test code.

Signed-off-by: Ji-Hyeon Gim <potatogim@potatogim.net>