### PR TITLE
Workaround to enable Markdown::Pod to test OK on older Perl versions…

### DIFF
--- a/lib/Markdown/Pod.pm
+++ b/lib/Markdown/Pod.pm
@@ -28,6 +28,7 @@ sub markdown_to_pod {
     my $capture = q{};
     open my $fh, '>', \$capture
         or die $!;
+    bless $fh, 'IO::File'; # A.Speer: Compatibility with older Perl versions
 
     if ($encoding) {
         my $found = first { $_ eq $encoding } Encode->encodings;


### PR DESCRIPTION
… (e.g. 5.16 on RHEL 7.9)

Fix for https://github.com/keedi/Markdown-Pod/issues/12